### PR TITLE
feat: make Recent First-Time Contributors clickable and show 20 contributors

### DIFF
--- a/components/dashboard-overview.tsx
+++ b/components/dashboard-overview.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import useSWR from 'swr'
-import { Star, GitFork, Users, Activity, Bot, UserPlus } from 'lucide-react'
+import Link from 'next/link'
+import { Star, GitFork, Users, Activity, Bot, UserPlus, ExternalLink } from 'lucide-react'
 import { DashboardData } from '@/types/github'
 import { formatNumber } from '@/lib/utils'
 import { LoadingSpinner } from './loading-card'
@@ -138,23 +139,34 @@ export function DashboardOverview() {
             <h3 className="font-heading font-semibold">Recent First-Time Contributors</h3>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {firstTimeContributors.slice(0, 12).map((contributor) => (
-              <div key={contributor.id} className="flex items-center space-x-3 p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+            {firstTimeContributors.slice(0, 20).map((contributor) => (
+              <Link
+                key={contributor.id}
+                href={contributor.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center space-x-3 p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group cursor-pointer"
+              >
                 <img
                   src={contributor.avatar_url}
                   alt={contributor.login}
                   className="w-8 h-8 rounded-full"
                 />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{contributor.name || contributor.login}</p>
+                  <div className="flex items-center space-x-1">
+                    <p className="text-sm font-medium truncate group-hover:text-primary transition-colors">
+                      {contributor.name || contributor.login}
+                    </p>
+                    <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </div>
                   <p className="text-xs text-muted-foreground">@{contributor.login}</p>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
-          {firstTimeContributors.length > 12 && (
+          {firstTimeContributors.length > 20 && (
             <p className="text-sm text-muted-foreground mt-4 text-center">
-              And {firstTimeContributors.length - 12} more first-time contributors...
+              And {firstTimeContributors.length - 20} more first-time contributors...
             </p>
           )}
         </div>


### PR DESCRIPTION
## Description

This PR implements the requested improvements to the "Recent First-Time Contributors" feature as described in issue #8.

## Changes Made

- ✅ **Made each contributor clickable**: Each contributor now links to their GitHub profile and opens in a new tab
- ✅ **Increased display limit**: Changed from showing 12 contributors to showing 20 contributors
- ✅ **Enhanced UX**: Added hover effects and external link icon that appears on hover
- ✅ **Updated counter text**: The "And X more..." text now reflects the new 20-contributor limit

## Technical Details

- Added `Link` component from Next.js for proper navigation
- Added `ExternalLink` icon from lucide-react for visual indication
- Implemented hover states with smooth transitions
- Updated slice limit from `slice(0, 12)` to `slice(0, 20)`
- Added proper accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`)

## Testing

- ✅ Application builds successfully without errors
- ✅ TypeScript compilation passes
- ✅ All existing functionality preserved

## Screenshots/Demo

The Recent First-Time Contributors section now:
- Shows up to 20 contributors (previously 12)
- Each contributor is clickable and opens their GitHub profile in a new tab
- Hover effects provide visual feedback
- External link icon appears on hover to indicate the link behavior

## Closes

Fixes #8

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37b7b416c7724390852c5ef363f08a5c)