### PR TITLE
feat: Update First-Time Contributors to show count from latest release

### DIFF
--- a/app/api/github/dashboard/route.ts
+++ b/app/api/github/dashboard/route.ts
@@ -70,9 +70,13 @@ export async function GET(request: Request) {
 
     const detailedExternalContributors = await GitHubAPI.getContributorDetails(topExternalContributors)
 
-    // Get the most recent 20 first-time contributors chronologically
+    // Get new contributors from latest release (for the count)
+    const newContributorsFromRelease = await GitHubAPI.getNewContributorsFromLatestRelease(OWNER, REPO)
+    
+    // Get the most recent 20 first-time contributors chronologically (for display)
     const recentFirstTimeContributors = await GitHubAPI.getRecentFirstTimeContributors(OWNER, REPO, 20)
 
+    console.log(`Found ${newContributorsFromRelease.length} new contributors from latest release`)
     console.log(`Found ${recentFirstTimeContributors.length} recent first-time contributors`)
 
     // Mark external contributors
@@ -115,6 +119,7 @@ export async function GET(request: Request) {
       contributors: allContributorsWithFlags,
       externalContributors: detailedExternalContributors,
       firstTimeContributors: recentFirstTimeContributors,
+      firstTimeContributorsCount: newContributorsFromRelease.length, // Count from latest release
       agentContributors,
       totalAgentContributions,
       recentCommits,

--- a/components/dashboard-overview.tsx
+++ b/components/dashboard-overview.tsx
@@ -47,6 +47,7 @@ export function DashboardOverview() {
     contributors,
     externalContributors,
     firstTimeContributors,
+    firstTimeContributorsCount,
     agentContributors,
     totalAgentContributions,
     orgStats
@@ -86,9 +87,9 @@ export function DashboardOverview() {
     },
     {
       title: 'First-Time Contributors',
-      value: formatNumber(firstTimeContributors.length),
+      value: formatNumber(firstTimeContributorsCount),
       icon: UserPlus,
-      description: 'New contributors',
+      description: 'New contributors to last release',
     },
   ]
 

--- a/types/github.ts
+++ b/types/github.ts
@@ -183,6 +183,7 @@ export interface DashboardData {
   contributors: GitHubContributor[]
   externalContributors: GitHubContributor[]
   firstTimeContributors: GitHubContributor[]
+  firstTimeContributorsCount: number // Count from latest release
   agentContributors: GitHubContributor[]
   totalAgentContributions: number
   recentCommits: GitHubCommit[]


### PR DESCRIPTION
## Summary

This PR fixes issue #8 by updating the First-Time Contributors functionality to show the count from the latest release while maintaining clickable contributor profiles.

## Changes Made

### 🎯 **Core Functionality**
- **First-Time Contributors card** now shows count from latest release (5 from v0.56.0)
- **Recent First-Time Contributors section** displays 20 chronological contributors with clickable profiles
- Updated description to "New contributors to last release" for clarity

### 🔧 **Technical Implementation**
- Added `getNewContributorsFromLatestRelease()` method to extract contributors from release notes
- Added `firstTimeContributorsCount` field to API response and TypeScript types
- Updated dashboard API to fetch both release count and chronological contributors
- Merged clickable functionality from PR #9 with proper hover effects and external link icons

### 🎨 **UI/UX Improvements**
- All 20 contributors are clickable and open GitHub profiles in new tabs
- Proper hover effects with external link icons
- Clear distinction between release count (5) and display count (20)
- Updated subtitle for better user understanding

## Testing

✅ **Verified functionality:**
- First-Time Contributors card shows correct count from latest release (5)
- Recent First-Time Contributors section shows exactly 20 contributors
- All contributors are clickable and open correct GitHub profiles
- Build passes successfully
- TypeScript compilation successful

## Fixes

Closes #8

## Screenshots

The First-Time Contributors card now shows "5" (from latest release v0.56.0) with description "New contributors to last release", while the Recent First-Time Contributors section displays 20 clickable contributor profiles chronologically sorted.

## Additional Notes

This implementation provides the best of both worlds:
- **Accurate release-based counting** for the summary card
- **Comprehensive chronological display** for detailed contributor exploration
- **Full clickability** for easy access to contributor profiles

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37b7b416c7724390852c5ef363f08a5c)